### PR TITLE
[1.20.1] Fix crash when biomes have been disabled via modloader methods.

### DIFF
--- a/Common/src/main/java/terrablender/mixin/MixinParameterList.java
+++ b/Common/src/main/java/terrablender/mixin/MixinParameterList.java
@@ -76,7 +76,10 @@ public abstract class MixinParameterList<T> implements IExtendedParameterList<T>
             else
             {
                 ImmutableList.Builder<Pair<Climate.ParameterPoint, Holder<Biome>>> builder = ImmutableList.builder();
-                region.addBiomes(biomeRegistry, pair -> builder.add(pair.mapSecond(biomeRegistry::getHolderOrThrow)));
+                region.addBiomes(biomeRegistry, pair -> {
+                    if (biomeRegistry.getHolder(pair.getSecond()).isPresent())
+                        builder.add(pair.mapSecond(biomeRegistry::getHolderOrThrow));
+                });
                 ImmutableList<Pair<Climate.ParameterPoint, Holder<Biome>>> uniqueValues = builder.build();
 
                 // We can't create an RTree if there are no values present.

--- a/Common/src/main/java/terrablender/util/LevelUtils.java
+++ b/Common/src/main/java/terrablender/util/LevelUtils.java
@@ -102,7 +102,10 @@ public class LevelUtils
         // Append modded biomes to the biome source biome list
         Registry<Biome> biomeRegistry = registryAccess.registryOrThrow(Registries.BIOME);
         ImmutableList.Builder<Holder<Biome>> builder = ImmutableList.builder();
-        Regions.get(regionType).forEach(region -> region.addBiomes(biomeRegistry, pair -> builder.add(biomeRegistry.getHolderOrThrow(pair.getSecond()))));
+        Regions.get(regionType).forEach(region -> region.addBiomes(biomeRegistry, pair -> {
+            if (biomeRegistry.getHolder(pair.getSecond()).isPresent())
+                builder.add(biomeRegistry.getHolderOrThrow(pair.getSecond()));
+        }));
         biomeSourceEx.appendDeferredBiomesList(builder.build());
 
         TerraBlender.LOGGER.info(String.format("Initialized TerraBlender biomes for level stem %s", levelResourceKey.location()));


### PR DESCRIPTION
This only really affects Forge right now, because Fabric only gained loading conditions to datapack registries in 1.20.6, but the game crashes if you disable a biome with loading conditions via the `forge:conditions` json array. This fixes this crash.

Tested with this line added to `biomesoplenty:bog`
```json
{
    "forge:conditions": [
        {
            "type": "forge:false"
        }
    ]
}
```