### PR TITLE
Create clean cache when generating biomes

### DIFF
--- a/Common/src/main/java/terrablender/mixin/MixinNoiseBasedChunkGenerator.java
+++ b/Common/src/main/java/terrablender/mixin/MixinNoiseBasedChunkGenerator.java
@@ -1,0 +1,23 @@
+package terrablender.mixin;
+
+import net.minecraft.world.level.biome.BiomeResolver;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import terrablender.worldgen.IExtendedMultiNoiseBiomeSource;
+
+@Mixin(NoiseBasedChunkGenerator.class)
+public class MixinNoiseBasedChunkGenerator {
+
+    @ModifyArg(method = "doCreateBiomes", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/chunk/ChunkAccess;fillBiomesFromNoise(Lnet/minecraft/world/level/biome/BiomeResolver;Lnet/minecraft/world/level/biome/Climate$Sampler;)V"))
+    private BiomeResolver modifyBiomeSource(BiomeResolver biomeResolver) {
+        if (biomeResolver instanceof MultiNoiseBiomeSource multiNoiseBiomeSource) {
+            return ((IExtendedMultiNoiseBiomeSource) multiNoiseBiomeSource).clone();
+        } else {
+            return biomeResolver;
+        }
+    }
+
+}

--- a/Common/src/main/java/terrablender/mixin/MultiNoiseBiomeSourceAccess.java
+++ b/Common/src/main/java/terrablender/mixin/MultiNoiseBiomeSourceAccess.java
@@ -1,0 +1,20 @@
+package terrablender.mixin;
+
+import com.mojang.datafixers.util.Either;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSourceParameterList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(MultiNoiseBiomeSource.class)
+public interface MultiNoiseBiomeSourceAccess {
+
+    @Mutable
+    @Accessor
+    void setParameters(Either<Climate.ParameterList<Holder<Biome>>, Holder<MultiNoiseBiomeSourceParameterList>> parameters);
+
+}

--- a/Common/src/main/java/terrablender/worldgen/IExtendedMultiNoiseBiomeSource.java
+++ b/Common/src/main/java/terrablender/worldgen/IExtendedMultiNoiseBiomeSource.java
@@ -1,0 +1,9 @@
+package terrablender.worldgen;
+
+import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+
+public interface IExtendedMultiNoiseBiomeSource extends Cloneable {
+
+    MultiNoiseBiomeSource clone();
+
+}

--- a/Common/src/main/java/terrablender/worldgen/IExtendedParameterList.java
+++ b/Common/src/main/java/terrablender/worldgen/IExtendedParameterList.java
@@ -22,7 +22,7 @@ import net.minecraft.world.level.biome.Climate;
 import terrablender.api.Region;
 import terrablender.api.RegionType;
 
-public interface IExtendedParameterList<T>
+public interface IExtendedParameterList<T> extends Cloneable
 {
     void initializeForTerraBlender(RegistryAccess registryAccess, RegionType regionType, long seed);
     T findValuePositional(Climate.TargetPoint target, int x, int y, int z);
@@ -31,4 +31,5 @@ public interface IExtendedParameterList<T>
     Region getRegion(int uniqueness);
     int getTreeCount();
     boolean isInitialized();
+    Climate.ParameterList<T> clone();
 }

--- a/Common/src/main/java/terrablender/worldgen/noise/LayeredNoiseUtil.java
+++ b/Common/src/main/java/terrablender/worldgen/noise/LayeredNoiseUtil.java
@@ -31,12 +31,20 @@ public class LayeredNoiseUtil
 {
     public static Area uniqueness(RegistryAccess registryAccess, RegionType regionType, long seed)
     {
+        return finalUniqueness(regionType, seed, initialUniqueness(registryAccess, regionType));
+    }
+
+    public static InitialLayer initialUniqueness(RegistryAccess registryAccess, RegionType regionType) {
+        return new InitialLayer(registryAccess, regionType);
+    }
+
+    public static Area finalUniqueness(RegionType regionType, long seed, InitialLayer initialLayer) {
         int numZooms = TerraBlender.CONFIG.overworldRegionSize;
 
         if (regionType == RegionType.NETHER)
             numZooms = TerraBlender.CONFIG.netherRegionSize;
 
-        return createZoomedArea(seed, numZooms, new InitialLayer(registryAccess, regionType));
+        return createZoomedArea(seed, numZooms, initialLayer);
     }
 
     public static Area biomeArea(RegistryAccess registryAccess, long seed, int size, List<WeightedEntry.Wrapper<ResourceKey<Biome>>> entries)

--- a/Common/src/main/resources/terrablender.mixins.json
+++ b/Common/src/main/resources/terrablender.mixins.json
@@ -8,10 +8,12 @@
     "MixinBuiltInRegistries",
     "MixinChunkGenerator",
     "MixinMultiNoiseBiomeSource",
+    "MixinNoiseBasedChunkGenerator",
     "MixinNoiseGeneratorSettings",
     "MixinParameterList",
     "MixinPrimaryLevelData",
-    "MixinTheEndBiomeSource"
+    "MixinTheEndBiomeSource",
+    "MultiNoiseBiomeSourceAccess"
   ],
   "client": [
     "MixinWorldOpenFlows"


### PR DESCRIPTION
In highly parallelized world generation environment, shared biome cache have several issues:
- high synchronization overhead
- cache pollution issue, as the entry needed for the current thread is released and recalculated due to cache sizing issues

This PR creates fresh cache for every invocation of `doCreateBiomes`, solving most of the issues above with negligible overhead. 

Before: https://spark.lucko.me/Y5GrKvrDsM?hl=168714 ([Y5GrKvrDsM.sparkprofile.gz](https://github.com/user-attachments/files/18305818/Y5GrKvrDsM.sparkprofile.gz))
After: https://spark.lucko.me/iaLAQPPt0I?hl=331359,314254 ([iaLAQPPt0I.sparkprofile.gz](https://github.com/user-attachments/files/18305820/iaLAQPPt0I.sparkprofile.gz))

