### PR TITLE
1.20.1 End Backport

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -1,5 +1,9 @@
+buildscript {
+    dependencies.add 'classpath', 'org.spongepowered:vanillagradle:0.2.1-20240507.024226-82'
+}
+
 plugins {
-    id 'org.spongepowered.gradle.vanilla' version '0.2.1-SNAPSHOT'
+    id 'org.spongepowered.gradle.vanilla' version '0.2.1-20240507.024226-82'
 }
 
 base.archivesName.set("${mod_name}-common")

--- a/Common/src/main/java/terrablender/api/EndBiomeRegistry.java
+++ b/Common/src/main/java/terrablender/api/EndBiomeRegistry.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (C) Glitchfiend
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package terrablender.api;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.random.WeightedEntry;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import terrablender.core.TerraBlender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EndBiomeRegistry
+{
+    private static final List<WeightedEntry.Wrapper<ResourceKey<Biome>>> highlandsBiomes = new ArrayList<>();
+    private static final List<WeightedEntry.Wrapper<ResourceKey<Biome>>> midlandsBiomes = new ArrayList<>();
+    private static final List<WeightedEntry.Wrapper<ResourceKey<Biome>>> edgeBiomes = new ArrayList<>();
+    private static final List<WeightedEntry.Wrapper<ResourceKey<Biome>>> islandBiomes = new ArrayList<>();
+
+    /**
+     * Registers a biome to generate in the highlands of the end.
+     * @param biome the biome to register.
+     * @param weight the biome weight.
+     */
+    public static void registerHighlandsBiome(ResourceKey<Biome> biome, int weight)
+    {
+        highlandsBiomes.add(WeightedEntry.wrap(biome, weight));
+    }
+
+    /**
+     * Registers a biome to generate in the midlands of the end.
+     * @param biome the biome to register.
+     * @param weight the biome weight.
+     */
+    public static void registerMidlandsBiome(ResourceKey<Biome> biome, int weight)
+    {
+        midlandsBiomes.add(WeightedEntry.wrap(biome, weight));
+    }
+
+    /**
+     * Registers a biome to generate in the outer edges of islands in the end.
+     * @param biome the biome to register.
+     * @param weight the biome weight.
+     */
+    public static void registerEdgeBiome(ResourceKey<Biome> biome, int weight)
+    {
+        edgeBiomes.add(WeightedEntry.wrap(biome, weight));
+    }
+
+    /**
+     * Registers a biome to generate as a small island of the end.
+     * @param biome the biome to register.
+     * @param weight the biome weight.
+     */
+    public static void registerIslandBiome(ResourceKey<Biome> biome, int weight)
+    {
+        islandBiomes.add(WeightedEntry.wrap(biome, weight));
+    }
+
+    /**
+     * Gets the biomes to generate in the highlands of the end.
+     * @return the biomes to generate.
+     */
+    public static List<WeightedEntry.Wrapper<ResourceKey<Biome>>> getHighlandsBiomes()
+    {
+        return ImmutableList.copyOf(highlandsBiomes);
+    }
+
+    /**
+     * Gets the biomes to generate in the midlands of the end.
+     * @return the biomes to generate.
+     */
+    public static List<WeightedEntry.Wrapper<ResourceKey<Biome>>> getMidlandsBiomes()
+    {
+        return ImmutableList.copyOf(midlandsBiomes);
+    }
+
+    /**
+     * Gets the biomes to generate in the outer edges of islands in the end.
+     * @return the biomes to generate.
+     */
+    public static List<WeightedEntry.Wrapper<ResourceKey<Biome>>> getEdgeBiomes()
+    {
+        return ImmutableList.copyOf(edgeBiomes);
+    }
+
+    /**
+     * Gets the biomes to generate as a small island of the end.
+     * @return the biomes to generate.
+     */
+    public static List<WeightedEntry.Wrapper<ResourceKey<Biome>>> getIslandBiomes()
+    {
+        return ImmutableList.copyOf(islandBiomes);
+    }
+
+    static
+    {
+        registerHighlandsBiome(Biomes.END_HIGHLANDS, TerraBlender.CONFIG.vanillaEndHighlandsWeight);
+        registerMidlandsBiome(Biomes.END_MIDLANDS, TerraBlender.CONFIG.vanillaEndMidlandsWeight);
+        registerEdgeBiome(Biomes.END_BARRENS, TerraBlender.CONFIG.vanillaEndBarrensWeight);
+        registerIslandBiome(Biomes.SMALL_END_ISLANDS, TerraBlender.CONFIG.vanillaSmallEndIslandsWeight);
+    }
+}

--- a/Common/src/main/java/terrablender/api/SurfaceRuleManager.java
+++ b/Common/src/main/java/terrablender/api/SurfaceRuleManager.java
@@ -116,6 +116,9 @@ public class SurfaceRuleManager
 
         if (category == RuleCategory.NETHER)
             return TBSurfaceRuleData.nether();
+        else if (category == RuleCategory.END) {
+            return TBSurfaceRuleData.end();
+        }
 
         return TBSurfaceRuleData.overworld();
     }
@@ -125,7 +128,7 @@ public class SurfaceRuleManager
      */
     public enum RuleCategory
     {
-        OVERWORLD, NETHER
+        OVERWORLD, NETHER, END
     }
 
     /**

--- a/Common/src/main/java/terrablender/config/Config.java
+++ b/Common/src/main/java/terrablender/config/Config.java
@@ -17,171 +17,218 @@
  */
 package terrablender.config;
 
-import com.electronwill.nightconfig.core.CommentedConfig;
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
+import com.electronwill.nightconfig.core.*;
 import com.electronwill.nightconfig.core.io.WritingMode;
 import com.electronwill.nightconfig.toml.TomlFormat;
-import com.electronwill.nightconfig.toml.TomlWriter;
-import net.minecraft.util.StringRepresentable;
+import com.google.common.base.Predicates;
+import terrablender.core.TerraBlender;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.stream.Collectors;
+import java.util.Set;
+import java.util.function.Predicate;
 
-public class Config
+public abstract class Config implements UnmodifiableConfig, CommentedConfig
 {
-    private final CommentedConfig config;
+    private CommentedConfig config;
+    private final Path path;
 
-    public Config(CommentedConfig config)
+    protected Config(Path path)
     {
-        this.config = config;
+        this(path, readToml(path));
     }
 
-    public <T> List<T> addList(String comment, String key, List<T> defaultValue)
+    protected Config(Path path, String toml)
     {
-        if (config.get(key) == null)
-        {
-            config.set(key, defaultValue);
-        }
-
-        if (config.getComment(key) == null)
-        {
-            config.setComment(key, comment);
-        }
-        return config.get(key);
+        this.parse(toml);
+        this.path = path;
+        this.load();
+        this.write();
     }
 
-    public Config addSubConfig(String comment, String key, Config defaultValue)
+    public <T> T add(String key, T defaultValue, String comment)
     {
-        if (config.get(key) == null)
-        {
-            config.set(key, sortConfig(defaultValue.config));
-        }
-
-        CommentedConfig subConfig = config.get(key);
-        String commentValue = config.getComment(key);
-        if (commentValue == null)
-        {
-            config.setComment(key, comment);
-        }
-
-        return new Config(subConfig);
+        return this.add(key, defaultValue, comment, Predicates.alwaysTrue());
     }
 
-    public Map<?, ?> addMap(String comment, String key, Map<?, Number> defaultValue)
+    public <T> T add(String key, T defaultValue, String comment, Predicate<T> validator)
     {
-        if (config.get(key) == null)
+        var value = config.getOrElse(key, defaultValue);
+
+        // Revert to default if validation fails
+        if (!validator.test(value))
         {
-            CommentedConfig subConfig = config.createSubConfig();
-            defaultValue.forEach((a, b) -> {
-                String subConfigKey = a.toString();
-                if (subConfig.get(a.toString()) == null)
-                {
-                    subConfig.set(subConfigKey, b);
-                }
-            });
-            config.set(key, subConfig);
+            TerraBlender.LOGGER.warn("Invalid value {} for key {}. Reverting to default", value, key);
+            value = defaultValue;
         }
 
-        CommentedConfig subConfig = config.get(key);
-        String commentValue = config.getComment(key);
-        if (commentValue == null)
-        {
-            config.setComment(key, comment);
-        }
-
-        return subConfig.valueMap();
+        config.set(key, value);
+        config.setComment(key, comment);
+        return value;
     }
 
-    public <T> T add(String comment, String key, T defaultValue)
+    public <T extends Number & Comparable<T>> T addNumber(String key, T defaultValue, T min, T max, String comment)
     {
-        if (config.get(key) == null)
-        {
-            config.set(key, defaultValue);
-        }
-
-        if (config.getComment(key) == null)
-        {
-            config.setComment(key, comment);
-        }
-        return config.get(key);
+        return this.add(key, defaultValue, comment, (v) -> v.compareTo(max) <= 0 && v.compareTo(min) >= 0);
     }
 
-    public <T extends Number & Comparable<T>> T addNumber(String comment, String key, T defaultValue, T min, T max)
-    {
-        if (config.get(key) == null)
-        {
-            config.set(key, defaultValue);
-        }
+    public abstract void load();
 
-        if (config.getComment(key) == null)
-        {
-            config.setComment(key, comment + String.format("\nRange: %s-%s", min, max));
-        }
-        T value = config.get(key);
-        return value.compareTo(max) > 0 ? max : value.compareTo(min) < 0 ? min : value;
+    public void parse(String toml)
+    {
+        this.config = TomlFormat.instance().createParser().parse(toml);
     }
 
-    public <T extends Enum<T>> T addEnum(String comment, String key, T defaultValue)
+    public void read()
     {
-        if (config.get(key) == null)
-        {
-            config.set(key, defaultValue);
-        }
-
-        if (config.getComment(key) == null)
-        {
-            StringBuilder builder = new StringBuilder().append("Values: ").append(defaultValue instanceof StringRepresentable ? "\n" : "");
-            for (T value : defaultValue.getDeclaringClass().getEnumConstants())
-            {
-                if (defaultValue instanceof StringRepresentable)
-                {
-                    builder.append(((StringRepresentable) value).getSerializedName()).append("\n");
-                }
-                else
-                {
-                    builder.append(value.name()).append(", ");
-                }
-            }
-
-            config.setComment(key, comment + "\n" + builder.toString());
-        }
-
-        String value = config.get(key).toString();
-        return T.valueOf(defaultValue.getDeclaringClass(), value);
+        this.parse(readToml(this.path));
     }
 
-    public <T> T getValue(String key)
+    public void write()
     {
-        return this.config.get(key);
+        TomlFormat.instance().createWriter().write(this.config, this.path, WritingMode.REPLACE);
     }
 
-    public Config getSubConfig(String key)
+    public String encode()
     {
-        CommentedConfig sub = this.config.get(key);
-        return new Config(sub != null ? sub : CommentedConfig.inMemory());
+        return TomlFormat.instance().createWriter().writeToString(this.config);
     }
 
-    protected CommentedConfig getConfig()
+    public Path getPath()
     {
-        return this.config;
+        return this.path;
     }
 
-    protected static CommentedConfig sortConfig(CommentedConfig config)
+    private static String readToml(Path path)
     {
-        CommentedConfig newConfig = CommentedConfig.of(com.electronwill.nightconfig.core.Config.getDefaultMapCreator(false, true), TomlFormat.instance());
+        // Create parent directories as needed
+        path.getParent().toFile().mkdirs();
 
-        List<Map.Entry<String, Object>> organizedCollection = config.valueMap().entrySet().stream().sorted(Comparator.comparing(Objects::toString)).collect(Collectors.toList());
-        organizedCollection.forEach((stringObjectEntry -> {
-            newConfig.add(stringObjectEntry.getKey(), stringObjectEntry.getValue());
-        }));
+        try {
+            return Files.readString(path);
+        } catch (Exception ignored) {}
+        return "";
+    }
 
-        newConfig.commentMap().putAll(config.commentMap());
-        return newConfig;
+    @Override
+    public <T> T getRaw(List<String> path) {
+        return config.getRaw(path);
+    }
+
+    @Override
+    public Map<String, Object> valueMap() {
+        return config.valueMap();
+    }
+
+    @Override
+    public boolean contains(List<String> path) {
+        return config.contains(path);
+    }
+
+    @Override
+    public int size() {
+        return config.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return config.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return config.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return config.hashCode();
+    }
+
+    @Override
+    public ConfigFormat<?> configFormat() {
+        return config.configFormat();
+    }
+
+    @Override
+    public <T> T set(List<String> path, Object value) {
+        return config.set(path, value);
+    }
+
+    @Override
+    public boolean add(List<String> path, Object value) {
+        return config.add(path, value);
+    }
+
+    @Override
+    public <T> T remove(List<String> path) {
+        return config.remove(path);
+    }
+
+    @Override
+    public void clear() {
+        config.clear();
+    }
+
+    @Override
+    public String getComment(List<String> path) {
+        return config.getComment(path);
+    }
+
+    @Override
+    public boolean containsComment(List<String> path) {
+        return config.containsComment(path);
+    }
+
+    @Override
+    public String setComment(List<String> path, String comment) {
+        return config.setComment(path, comment);
+    }
+
+    @Override
+    public String removeComment(List<String> path) {
+        return config.removeComment(path);
+    }
+
+    @Override
+    public Map<String, String> commentMap() {
+        return config.commentMap();
+    }
+
+    @Override
+    public Set<? extends CommentedConfig.Entry> entrySet() {
+        return config.entrySet();
+    }
+
+    @Override
+    public void clearComments() {
+        config.clearComments();
+    }
+
+    @Override
+    public void putAllComments(Map<String, UnmodifiableCommentedConfig.CommentNode> comments) {
+        config.putAllComments(comments);
+    }
+
+    @Override
+    public void putAllComments(UnmodifiableCommentedConfig commentedConfig) {
+        config.putAllComments(commentedConfig);
+    }
+
+    @Override
+    public Map<String, UnmodifiableCommentedConfig.CommentNode> getComments() {
+        return config.getComments();
+    }
+
+    @Override
+    public CommentedConfig createSubConfig() {
+        return config.createSubConfig();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + ':' + config;
     }
 }

--- a/Common/src/main/java/terrablender/config/TerraBlenderConfig.java
+++ b/Common/src/main/java/terrablender/config/TerraBlenderConfig.java
@@ -19,27 +19,42 @@ package terrablender.config;
 
 import java.nio.file.Path;
 
-public class TerraBlenderConfig extends ConfigFile
+public class TerraBlenderConfig extends Config
 {
-    public final int overworldRegionSize;
-    public final int netherRegionSize;
-    public final int vanillaOverworldRegionWeight;
-    public final int vanillaNetherRegionWeight;
+    public int overworldRegionSize;
+    public int netherRegionSize;
+    public int vanillaOverworldRegionWeight;
+    public int vanillaNetherRegionWeight;
+
+    public int endHighlandsBiomeSize;
+    public int endMidlandsBiomeSize;
+    public int endEdgeBiomeSize;
+    public int endIslandBiomeSize;
+    public int vanillaEndHighlandsWeight;
+    public int vanillaEndMidlandsWeight;
+    public int vanillaEndBarrensWeight;
+    public int vanillaSmallEndIslandsWeight;
 
     public TerraBlenderConfig(Path path)
     {
         super(path);
+    }
 
-        Config generalConfig = this.getSubConfig("general");
-        this.addSubConfig("General settings", "general", generalConfig);
+    @Override
+    public void load()
+    {
+        this.overworldRegionSize = addNumber("general.overworld_region_size", 3, 2, 6, "The size of overworld biome regions from each mod that uses TerraBlender.");
+        this.netherRegionSize = addNumber("general.nether_region_size", 2, 2, 6, "The size of nether biome regions from each mod that uses TerraBlender.");
+        this.vanillaOverworldRegionWeight = addNumber("general.vanilla_overworld_region_weight", 10, 0, Integer.MAX_VALUE, "The weighting of vanilla biome regions in the overworld.");
+        this.vanillaNetherRegionWeight = addNumber("general.vanilla_nether_region_weight", 10, 0, Integer.MAX_VALUE, "The weighting of vanilla biome regions in the nether.");
 
-        Config generationSettings = this.getSubConfig("generation_settings");
-        this.overworldRegionSize = generationSettings.addNumber("The size of overworld biome regions from each mod that uses TerraBlender.", "overworld_region_size", 3, 2, 6);
-        this.netherRegionSize = generationSettings.addNumber("The size of nether biome regions from each mod that uses TerraBlender.", "nether_region_size", 2, 2, 6);
-        this.vanillaOverworldRegionWeight = generationSettings.addNumber("The weighting of vanilla biome regions in the overworld.", "vanilla_overworld_region_weight", 10, 0, Integer.MAX_VALUE);
-        this.vanillaNetherRegionWeight = generationSettings.addNumber("The weighting of vanilla biome regions in the nether.", "vanilla_nether_region_weight", 10, 0, Integer.MAX_VALUE);
-        this.addSubConfig("Generation settings", "generation_settings", generationSettings);
-
-        this.save();
+        this.endHighlandsBiomeSize = addNumber("end.highlands_biome_size", 4, 2, 6, "The size of highlands end biomes.");
+        this.endMidlandsBiomeSize = addNumber("end.midlands_biome_size", 4, 2, 6, "The size of midlands end biomes.");
+        this.endEdgeBiomeSize = addNumber("end.edge_biome_size", 3, 2, 6, "The size of edge end biomes.");
+        this.endIslandBiomeSize = addNumber("end.island_biome_size", 2, 2, 6, "The size of island end biomes.");
+        this.vanillaEndHighlandsWeight = addNumber("end.vanilla_end_highlands_weight", 10, 0, Integer.MAX_VALUE, "The weight of Vanilla end highlands biomes.");
+        this.vanillaEndMidlandsWeight = addNumber("end.vanilla_end_midlands_weight", 10, 0, Integer.MAX_VALUE, "The weight of Vanilla end midlands biomes.");
+        this.vanillaEndBarrensWeight = addNumber("end.vanilla_end_barrens_weight", 10, 0, Integer.MAX_VALUE, "The weight of Vanilla end barrens biomes.");
+        this.vanillaSmallEndIslandsWeight = addNumber("end.vanilla_small_end_islands_weight", 10, 0, Integer.MAX_VALUE, "The weight of Vanilla small end islands biomes.");
     }
 }

--- a/Common/src/main/java/terrablender/mixin/MixinBiomeSource.java
+++ b/Common/src/main/java/terrablender/mixin/MixinBiomeSource.java
@@ -17,23 +17,21 @@
  */
 package terrablender.mixin;
 
-import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeResolver;
 import net.minecraft.world.level.biome.BiomeSource;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.Unique;
 import terrablender.worldgen.IExtendedBiomeSource;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 @Mixin(BiomeSource.class)
 public abstract class MixinBiomeSource implements BiomeResolver, IExtendedBiomeSource
@@ -41,6 +39,7 @@ public abstract class MixinBiomeSource implements BiomeResolver, IExtendedBiomeS
     @Shadow
     public Supplier<Set<Holder<Biome>>> possibleBiomes;
 
+    @Unique
     private boolean hasAppended = false;
 
     @Override
@@ -51,12 +50,11 @@ public abstract class MixinBiomeSource implements BiomeResolver, IExtendedBiomeS
             return;
         }
 
-        ImmutableList.Builder<Holder<Biome>> builder = ImmutableList.builder();
-        builder.addAll(this.possibleBiomes.get());
-        builder.addAll(biomesToAppend);
-        ImmutableList<Holder<Biome>> biomeList = builder.build().stream().distinct().collect(ImmutableList.toImmutableList());
+        List<Holder<Biome>> possibleBiomes = new ArrayList<>();
+        possibleBiomes.addAll(this.possibleBiomes.get());
+        possibleBiomes.addAll(biomesToAppend);
 
-        this.possibleBiomes = () -> new ObjectLinkedOpenHashSet<>(biomeList);
+        this.possibleBiomes = () -> new ObjectLinkedOpenHashSet<>(possibleBiomes.stream().distinct().collect(Collectors.toList()));
         this.hasAppended = true;
     }
 }

--- a/Common/src/main/java/terrablender/mixin/MixinNoiseGeneratorSettings.java
+++ b/Common/src/main/java/terrablender/mixin/MixinNoiseGeneratorSettings.java
@@ -21,6 +21,7 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
@@ -35,30 +36,26 @@ public class MixinNoiseGeneratorSettings implements IExtendedNoiseGeneratorSetti
     @Shadow
     private SurfaceRules.RuleSource surfaceRule;
 
-    private RegionType regionType = null;
+    @Unique
+    private SurfaceRuleManager.RuleCategory ruleCategory = null;
+    @Unique
     private SurfaceRules.RuleSource namespacedSurfaceRuleSource = null;
 
     @Inject(method = "surfaceRule", at = @At("HEAD"), cancellable = true)
     private void surfaceRule(CallbackInfoReturnable<SurfaceRules.RuleSource> cir)
     {
-        if (this.regionType != null)
+        if (this.ruleCategory != null)
         {
             if (this.namespacedSurfaceRuleSource == null)
-                this.namespacedSurfaceRuleSource = regionType == RegionType.NETHER ? SurfaceRuleManager.getNamespacedRules(SurfaceRuleManager.RuleCategory.NETHER, this.surfaceRule) : SurfaceRuleManager.getNamespacedRules(SurfaceRuleManager.RuleCategory.OVERWORLD, this.surfaceRule);
+                this.namespacedSurfaceRuleSource = SurfaceRuleManager.getNamespacedRules(this.ruleCategory, this.surfaceRule);
 
             cir.setReturnValue(this.namespacedSurfaceRuleSource);
         }
     }
 
     @Override
-    public void setRegionType(RegionType regionType)
+    public void setRuleCategory(SurfaceRuleManager.RuleCategory ruleCategory)
     {
-        this.regionType = regionType;
-    }
-
-    @Override
-    public RegionType getRegionType()
-    {
-        return this.regionType;
+        this.ruleCategory = ruleCategory;
     }
 }

--- a/Common/src/main/java/terrablender/mixin/MixinParameterList.java
+++ b/Common/src/main/java/terrablender/mixin/MixinParameterList.java
@@ -28,6 +28,7 @@ import net.minecraft.world.level.biome.Climate;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import terrablender.api.Region;
 import terrablender.api.RegionType;
 import terrablender.api.Regions;
@@ -47,9 +48,13 @@ public abstract class MixinParameterList<T> implements IExtendedParameterList<T>
     @Shadow
     public abstract T findValue(Climate.TargetPoint target);
 
+    @Unique
     private boolean initialized = false;
+    @Unique
     private boolean treesPopulated = false;
+    @Unique
     private Area uniqueness;
+    @Unique
     private Climate.RTree[] uniqueTrees;
 
     @Override

--- a/Common/src/main/java/terrablender/mixin/MixinTheEndBiomeSource.java
+++ b/Common/src/main/java/terrablender/mixin/MixinTheEndBiomeSource.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) Glitchfiend
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package terrablender.mixin;
+
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.core.*;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.random.WeightedEntry;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.biome.TheEndBiomeSource;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import terrablender.api.EndBiomeRegistry;
+import terrablender.core.TerraBlender;
+import terrablender.worldgen.IExtendedTheEndBiomeSource;
+import terrablender.worldgen.noise.Area;
+import terrablender.worldgen.noise.LayeredNoiseUtil;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Mixin(TheEndBiomeSource.class)
+public class MixinTheEndBiomeSource implements IExtendedTheEndBiomeSource
+{
+    @Shadow
+    @Final
+    private Holder<Biome> end;
+
+    @Unique
+    private boolean tbInitialized = false;
+
+    @Unique
+    private Registry<Biome> biomeRegistry;
+    @Unique
+    private Set<Holder<Biome>> tbPossibleBiomes;
+    @Unique
+    private Area highlandsArea;
+    @Unique
+    private Area midlandsArea;
+    @Unique
+    private Area edgeArea;
+    @Unique
+    private Area islandsArea;
+
+    @Override
+    public void initializeForTerraBlender(RegistryAccess registryAccess, long seed)
+    {
+        this.biomeRegistry = registryAccess.registryOrThrow(Registries.BIOME);
+
+        var highlands = EndBiomeRegistry.getHighlandsBiomes();
+        var midlands = EndBiomeRegistry.getMidlandsBiomes();
+        var edge = EndBiomeRegistry.getEdgeBiomes();
+        var islands = EndBiomeRegistry.getIslandBiomes();
+
+        // Create a set of all biomes
+        var builder = ImmutableSet.<ResourceKey<Biome>>builder();
+        builder.addAll(highlands.stream().map(WeightedEntry.Wrapper::getData).toList());
+        builder.addAll(midlands.stream().map(WeightedEntry.Wrapper::getData).toList());
+        builder.addAll(edge.stream().map(WeightedEntry.Wrapper::getData).toList());
+        builder.addAll(islands.stream().map(WeightedEntry.Wrapper::getData).toList());
+        builder.add(Biomes.THE_END);
+        Set<ResourceKey<Biome>> allBiomes = builder.build();
+
+        // Ensure all biomes are registered
+        allBiomes.forEach(key -> {
+            if (!biomeRegistry.containsKey(key))
+                throw new RuntimeException("Biome " + key + " has not been registered!");
+        });
+
+        this.tbPossibleBiomes = allBiomes.stream().map(biomeRegistry::getHolderOrThrow).collect(Collectors.toSet());
+        this.highlandsArea = LayeredNoiseUtil.biomeArea(registryAccess, seed, TerraBlender.CONFIG.endHighlandsBiomeSize, highlands);
+        this.midlandsArea = LayeredNoiseUtil.biomeArea(registryAccess, seed, TerraBlender.CONFIG.endMidlandsBiomeSize, midlands);
+        this.edgeArea = LayeredNoiseUtil.biomeArea(registryAccess, seed, TerraBlender.CONFIG.endEdgeBiomeSize, edge);
+        this.islandsArea = LayeredNoiseUtil.biomeArea(registryAccess, seed, TerraBlender.CONFIG.endIslandBiomeSize, edge);
+
+        // This may not be initialized with e.g. BCLib
+        this.tbInitialized = true;
+    }
+
+    @Inject(method = "collectPossibleBiomes", at=@At("RETURN"), cancellable = true)
+    protected void onCollectPossibleBiomes(CallbackInfoReturnable<Stream<Holder<Biome>>> cir)
+    {
+        if (!this.tbInitialized)
+            return;
+
+        var builder = ImmutableSet.<Holder<Biome>>builder();
+        builder.addAll(cir.getReturnValue().collect(Collectors.toSet()));
+        builder.addAll(this.tbPossibleBiomes);
+        cir.setReturnValue(builder.build().stream());
+    }
+
+    @Inject(method = "getNoiseBiome", at=@At("HEAD"), cancellable = true)
+    public void onGetNoiseBiome(int x, int y, int z, Climate.Sampler sampler, CallbackInfoReturnable<Holder<Biome>> cir)
+    {
+        if (!this.tbInitialized)
+            return;
+
+        int blockX = QuartPos.toBlock(x);
+        int blockY = QuartPos.toBlock(y);
+        int blockZ = QuartPos.toBlock(z);
+
+        int sectionX = SectionPos.blockToSectionCoord(blockX);
+        int sectionZ = SectionPos.blockToSectionCoord(blockZ);
+
+        if ((long)sectionX * (long)sectionX + (long)sectionZ * (long)sectionZ <= 4096L)
+        {
+            cir.setReturnValue(this.end);
+        }
+        else
+        {
+            double heightNoise = sampler.erosion().compute(new DensityFunction.SinglePointContext(blockX, blockY, blockZ));
+
+            if (heightNoise > 0.25)
+            {
+                cir.setReturnValue(this.getBiomeHolder(this.highlandsArea.get(x, z)));
+            }
+            else if (heightNoise >= -0.0625)
+            {
+                cir.setReturnValue(this.getBiomeHolder(this.midlandsArea.get(x, z)));
+            }
+            else
+            {
+                cir.setReturnValue(heightNoise < -0.21875 ? this.getBiomeHolder(this.islandsArea.get(x, z)) : this.getBiomeHolder(this.edgeArea.get(x, z)));
+            }
+        }
+    }
+
+    @Unique
+    private Holder<Biome> getBiomeHolder(int id)
+    {
+        return this.biomeRegistry.getHolder(id).orElseThrow();
+    }
+}

--- a/Common/src/main/java/terrablender/util/LevelUtils.java
+++ b/Common/src/main/java/terrablender/util/LevelUtils.java
@@ -24,10 +24,7 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeSource;
-import net.minecraft.world.level.biome.Climate;
-import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.biome.*;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.dimension.LevelStem;
@@ -36,10 +33,12 @@ import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import terrablender.DimensionTypeTags;
 import terrablender.api.RegionType;
 import terrablender.api.Regions;
+import terrablender.api.SurfaceRuleManager;
 import terrablender.core.TerraBlender;
 import terrablender.worldgen.IExtendedBiomeSource;
 import terrablender.worldgen.IExtendedNoiseGeneratorSettings;
 import terrablender.worldgen.IExtendedParameterList;
+import terrablender.worldgen.IExtendedTheEndBiomeSource;
 
 import java.util.Map;
 
@@ -77,12 +76,20 @@ public class LevelUtils
 
     public static void initializeBiomes(RegistryAccess registryAccess, Holder<DimensionType> dimensionType, ResourceKey<LevelStem> levelResourceKey, ChunkGenerator chunkGenerator, long seed)
     {
-        if (!shouldApplyToChunkGenerator(chunkGenerator))
+        if (!(chunkGenerator instanceof NoiseBasedChunkGenerator noiseBasedChunkGenerator))
             return;
 
-        RegionType regionType = getRegionTypeForDimension(dimensionType);
-        NoiseBasedChunkGenerator noiseBasedChunkGenerator = (NoiseBasedChunkGenerator)chunkGenerator;
         NoiseGeneratorSettings generatorSettings = noiseBasedChunkGenerator.generatorSettings().value();
+
+        if (chunkGenerator.getBiomeSource() instanceof TheEndBiomeSource)
+        {
+            ((IExtendedTheEndBiomeSource)chunkGenerator.getBiomeSource()).initializeForTerraBlender(registryAccess, seed);
+            ((IExtendedNoiseGeneratorSettings)(Object)generatorSettings).setRuleCategory(SurfaceRuleManager.RuleCategory.END);
+            return;
+        }
+        else if (!shouldApplyToBiomeSource(chunkGenerator.getBiomeSource())) return;
+
+        RegionType regionType = getRegionTypeForDimension(dimensionType);
         MultiNoiseBiomeSource biomeSource = (MultiNoiseBiomeSource)chunkGenerator.getBiomeSource();
         IExtendedBiomeSource biomeSourceEx = (IExtendedBiomeSource)biomeSource;
 
@@ -91,7 +98,12 @@ public class LevelUtils
             return;
 
         // Set the chunk generator settings' region type
-        ((IExtendedNoiseGeneratorSettings)(Object)generatorSettings).setRegionType(regionType);
+        SurfaceRuleManager.RuleCategory ruleCategory = switch(regionType) {
+            case OVERWORLD -> SurfaceRuleManager.RuleCategory.OVERWORLD;
+            case NETHER -> SurfaceRuleManager.RuleCategory.NETHER;
+            default -> throw new IllegalArgumentException("Attempted to get surface rule category for unsupported region type " + regionType);
+        };
+        ((IExtendedNoiseGeneratorSettings)(Object)generatorSettings).setRuleCategory(ruleCategory);
 
         Climate.ParameterList parameters = biomeSource.parameters();
         IExtendedParameterList parametersEx = (IExtendedParameterList)parameters;

--- a/Common/src/main/java/terrablender/util/WeightedRandomList.java
+++ b/Common/src/main/java/terrablender/util/WeightedRandomList.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright 2024, the Glitchfiend Team.
+ * All rights reserved.
+ ******************************************************************************/
+package terrablender.util;
+
+import com.google.common.collect.ImmutableList;
+import net.minecraft.util.random.WeightedEntry;
+import net.minecraft.util.random.WeightedRandom;
+import terrablender.worldgen.noise.AreaContext;
+import terrablender.worldgen.noise.WeightedRandomLayer;
+
+import java.util.List;
+import java.util.Optional;
+
+public class WeightedRandomList<E extends WeightedEntry>
+{
+    private final int totalWeight;
+    private final ImmutableList<E> items;
+
+    WeightedRandomList(List<? extends E> items)
+    {
+        this.items = ImmutableList.copyOf(items);
+        this.totalWeight = WeightedRandom.getTotalWeight(items);
+    }
+
+    public static <E extends WeightedEntry> WeightedRandomList<E> create()
+    {
+        return new WeightedRandomList<>(ImmutableList.of());
+    }
+
+    @SafeVarargs
+    public static <E extends WeightedEntry> WeightedRandomList<E> create(E... entries)
+    {
+        return new WeightedRandomList<>(ImmutableList.copyOf(entries));
+    }
+
+    public static <E extends WeightedEntry> WeightedRandomList<E> create(List<E> entries)
+    {
+        return new WeightedRandomList<>(entries);
+    }
+
+    public Optional<E> getRandom(AreaContext context)
+    {
+        if (this.totalWeight == 0) {
+            return Optional.empty();
+        } else {
+            int i = context.nextRandom(this.totalWeight);
+            return WeightedRandom.getWeightedItem(this.items, i);
+        }
+    }
+}

--- a/Common/src/main/java/terrablender/worldgen/IExtendedTheEndBiomeSource.java
+++ b/Common/src/main/java/terrablender/worldgen/IExtendedTheEndBiomeSource.java
@@ -17,9 +17,11 @@
  */
 package terrablender.worldgen;
 
-import terrablender.api.SurfaceRuleManager;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.world.level.biome.Climate;
+import terrablender.api.RegionType;
 
-public interface IExtendedNoiseGeneratorSettings
+public interface IExtendedTheEndBiomeSource
 {
-    void setRuleCategory(SurfaceRuleManager.RuleCategory ruleCategory);
+    void initializeForTerraBlender(RegistryAccess registryAccess, long seed);
 }

--- a/Common/src/main/java/terrablender/worldgen/TBSurfaceRuleData.java
+++ b/Common/src/main/java/terrablender/worldgen/TBSurfaceRuleData.java
@@ -650,6 +650,11 @@ public class TBSurfaceRuleData
         return SurfaceRules.sequence(builder.build().toArray(SurfaceRules.RuleSource[]::new));
     }
 
+    public static SurfaceRules.RuleSource end()
+    {
+        return ENDSTONE;
+    }
+
     public static SurfaceRules.RuleSource air()
     {
         return AIR;

--- a/Common/src/main/java/terrablender/worldgen/noise/BiomeInitialLayer.java
+++ b/Common/src/main/java/terrablender/worldgen/noise/BiomeInitialLayer.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright 2024, the Glitchfiend Team.
+ * All rights reserved.
+ ******************************************************************************/
+package terrablender.worldgen.noise;
+
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.random.WeightedEntry;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+
+import java.util.List;
+
+public class BiomeInitialLayer extends WeightedRandomLayer<WeightedEntry.Wrapper<ResourceKey<Biome>>>
+{
+    private final Registry<Biome> biomeRegistry;
+
+    public BiomeInitialLayer(RegistryAccess registryAccess, List<WeightedEntry.Wrapper<ResourceKey<Biome>>> entries)
+    {
+        super(entries);
+        this.biomeRegistry = registryAccess.registryOrThrow(Registries.BIOME);
+    }
+
+    @Override
+    protected int getEntryIndex(WeightedEntry.Wrapper<ResourceKey<Biome>> entry)
+    {
+        return this.resolveId(entry.getData());
+    }
+
+    @Override
+    protected int getDefaultIndex()
+    {
+        return this.resolveId(Biomes.OCEAN);
+    }
+
+    private int resolveId(ResourceKey<Biome> key)
+    {
+        if (!this.biomeRegistry.containsKey(key))
+            throw new RuntimeException("Attempted to resolve id for unregistered biome " + key);
+
+        return this.biomeRegistry.getId(this.biomeRegistry.get(key));
+    }
+}

--- a/Common/src/main/java/terrablender/worldgen/noise/WeightedRandomLayer.java
+++ b/Common/src/main/java/terrablender/worldgen/noise/WeightedRandomLayer.java
@@ -5,37 +5,42 @@
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package terrablender.config;
+package terrablender.worldgen.noise;
 
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
-import com.electronwill.nightconfig.core.io.WritingMode;
-import com.electronwill.nightconfig.toml.TomlWriter;
+import net.minecraft.util.random.WeightedEntry;
+import terrablender.util.WeightedRandomList;
 
-import java.nio.file.Path;
+import java.util.List;
 
-public class ConfigFile extends Config
+public abstract class WeightedRandomLayer<T extends WeightedEntry> implements AreaTransformer0
 {
-    private final Path path;
+    private final WeightedRandomList<T> weightedEntries;
 
-    public ConfigFile(Path path)
+    public WeightedRandomLayer(List<T> entries)
     {
-        super(CommentedFileConfig.builder(path).sync().autosave().build());
-        this.path = path;
-        ((CommentedFileConfig)this.getConfig()).load();
+        this.weightedEntries = WeightedRandomList.create(entries);
     }
 
-    public void save()
+    @Override
+    public int apply(AreaContext context, int x, int y)
     {
-        (new TomlWriter()).write(sortConfig(this.getConfig()), this.path.toFile(), WritingMode.REPLACE);
+        return this.weightedEntries.getRandom(context).map(this::getEntryIndex).orElse(getDefaultIndex());
+    }
+
+    protected abstract int getEntryIndex(T entry);
+
+    protected int getDefaultIndex()
+    {
+        return 0;
     }
 }

--- a/Common/src/main/resources/terrablender.mixins.json
+++ b/Common/src/main/resources/terrablender.mixins.json
@@ -9,7 +9,8 @@
     "MixinMultiNoiseBiomeSource",
     "MixinNoiseGeneratorSettings",
     "MixinParameterList",
-    "MixinPrimaryLevelData"
+    "MixinPrimaryLevelData",
+    "MixinTheEndBiomeSource"
   ],
   "client": [
     "MixinWorldOpenFlows"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ forge_ats_enabled=true
 
 # Fabric
 fabric_version=0.83.1+1.20.1
-fabric_loader_version=0.14.21
+fabric_loader_version=0.15.0
 
 # Mod options
 mod_name=TerraBlender


### PR DESCRIPTION
Backports End support to 1.20.1

The manner is simple: Revert the revert of #164

Bear with me. #165 was actually caused by Cristel-Lib mixing into TerraBlenderConfig and not finding their injection target, and was something they had fixed in post-1.20.1 versions: https://github.com/Cristelknight999/Cristel-Lib/commit/667f5b6b900a847ce6c061769c4c9a7067a3f91c, but never got the chance to with this version of the mod because of the quick revert.

Ignoring that, the version from that PR (and thus this one) also crashed on the world loading when used with Aeroblender, which they also fixed post-1.20.1: https://github.com/RazorDevs/Aeroblender/commit/893af503ba861ef539d46df53e2f7679ec5a827c. 

So there's fundamentally nothing wrong with the initial PR. But, in the spirit of compatibility, I have opened PR's with both these mods to backport their fixes too, using the fortunately released 3.0.1.5 to compile against, and so perhaps you could coordinate a release.
I had looked into rewriting the backport s.t. their injections points were still valid, but that seemed both unwise and messy.

I've tested that this PR does not crash the game (when used with the above fixes applied), on both Forge and Fabric, with decently sized modpacks containing multiple big biome mods, just flying around, verifying that biomes were still generating.

I had to pin the VanillaGradle version and just picked the latest one available at the last 1.20.1 release. For some reason, the one it currently picks by default couldn't resolve any of the Common dependencies.