### PR TITLE
Reorder generator validation check in LevelUtils

### DIFF
--- a/common/src/main/java/terrablender/util/LevelUtils.java
+++ b/common/src/main/java/terrablender/util/LevelUtils.java
@@ -87,11 +87,8 @@ public class LevelUtils
             ((IExtendedNoiseGeneratorSettings)(Object)generatorSettings).setRuleCategory(SurfaceRuleManager.RuleCategory.END);
             return;
         }
-        else if (!shouldApplyToBiomeSource(chunkGenerator.getBiomeSource())) return;
 
         RegionType regionType = getRegionTypeForDimension(dimensionType);
-        MultiNoiseBiomeSource biomeSource = (MultiNoiseBiomeSource)chunkGenerator.getBiomeSource();
-        IExtendedBiomeSource biomeSourceEx = (IExtendedBiomeSource)biomeSource;
 
         // Don't continue if region type is uninitialized
         if (regionType == null)
@@ -104,6 +101,11 @@ public class LevelUtils
             default -> throw new IllegalArgumentException("Attempted to get surface rule category for unsupported region type " + regionType);
         };
         ((IExtendedNoiseGeneratorSettings)(Object)generatorSettings).setRuleCategory(ruleCategory);
+
+        if (!shouldApplyToBiomeSource(chunkGenerator.getBiomeSource())) return;
+
+        MultiNoiseBiomeSource biomeSource = (MultiNoiseBiomeSource)chunkGenerator.getBiomeSource();
+        IExtendedBiomeSource biomeSourceEx = (IExtendedBiomeSource)biomeSource;
 
         Climate.ParameterList parameters = biomeSource.parameters();
         IExtendedParameterList parametersEx = (IExtendedParameterList)parameters;


### PR DESCRIPTION
Adjust generator validation check to allow modded surface rules on non-standard biome sources. This allows biome-specific surfaces rules to be loaded on, for example, the single-biome world generator. Should fix #208, and be simple enough to backport.

Example single biome world before/after with a biome using the desert surface rule.
<img width="854" height="480" alt="javaw_DRhBga8bNY" src="https://github.com/user-attachments/assets/46ab92df-1725-49e2-b2c9-30efef7c1d71" />
<img width="854" height="480" alt="javaw_1jCe1ilBmw" src="https://github.com/user-attachments/assets/317b298a-9735-4272-b6eb-b19e0f906c58" />
