### PR TITLE
Update 26.1.2 build and CI tooling

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -10,21 +10,23 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      GRADLE_OPTS: --enable-native-access=ALL-UNNAMED
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
     - name: Set up JDK 25
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v5
       with:
         java-version: '25'
-        distribution: 'oracle'
+        distribution: 'temurin'
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v6
     - name: Publish
       run: ./gradlew publish
       env:

--- a/build.gradle
+++ b/build.gradle
@@ -17,11 +17,11 @@ apply plugin: 'org.jetbrains.gradle.plugin.idea-ext'
 apply plugin: 'net.minecraftforge.gradleutils'
 
 changelog {
-    fromTag '3.2.0'
+    from '3.2.0'
 }
 
 ext {
-    mod_version = gradleutils.getTagOffsetVersion()
+    mod_version = gitversion.tagOffset
     changelog_file = rootProject.file("build/changelog.txt")
     trimChangelog = (String text) -> {
         def m = text =~ /(?s) - (?:[0-9.]+) (.+?)(?=( - )|$)/
@@ -222,9 +222,9 @@ subprojects {
         publishing {
             publications {
                 mavenJava(MavenPublication) {
-                    artifactId project.base.archivesName.get()
-                    groupId project.group
-                    version project.version
+                    artifactId = project.base.archivesName.get()
+                    groupId = project.group
+                    version = project.version
                     from components.java
 
                     pom {
@@ -257,18 +257,31 @@ subprojects {
                         }
                         withXml {
                             NodeList dependencies = asNode().dependencies
-                            NodeList allDeps = dependencies.'*'
+                            List<Node> forgeDeps = []
+                            List<Node> mappedDeps = []
+
+                            for (Object dependencyNode : dependencies.'*') {
+                                if (!(dependencyNode instanceof Node)) {
+                                    continue
+                                }
+
+                                Node dep = (Node) dependencyNode
+
+                                if (dep.artifactId.text() == 'forge' && dep.groupId.text() == 'net.minecraftforge') {
+                                    forgeDeps.add(dep)
+                                }
+
+                                if (dep.version.text().contains('_mapped_')) {
+                                    mappedDeps.add(dep)
+                                }
+                            }
 
                             // Remove forge deps
-                            allDeps.<Node> findAll() { Node el ->
-                                el.artifactId.text() == 'forge' && el.groupId.text() == 'net.minecraftforge'
-                            }.forEach() { Node el ->
+                            forgeDeps.forEach() { Node el ->
                                 el.parent().remove(el)
                             }
                             // Remove ForgeGradle's mapped suffix from versions & set as optional so anyone else doesn't inherit them
-                            allDeps.<Node> findAll() { Node el ->
-                                el.version.text().contains('_mapped_')
-                            }.each { Node el ->
+                            mappedDeps.each { Node el ->
                                 el.version.each { Node version ->
                                     def versionText = version.text()
                                     version.setValue(versionText.substring(0, versionText.indexOf('_mapped_')))

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,9 +14,9 @@ neoForge {
 }
 
 dependencies {
-    compileOnly group:'org.spongepowered', name: 'mixin', version: '0.8.5'
-    compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
-    annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
+    compileOnly 'org.spongepowered:mixin:0.8.5'
+    compileOnly 'io.github.llamalad7:mixinextras-common:0.3.5'
+    annotationProcessor 'io.github.llamalad7:mixinextras-common:0.3.5'
     compileOnly("com.electronwill.night-config:toml:${nightconfig_version}")
     compileOnly("com.electronwill.night-config:core:${nightconfig_version}")
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "net.fabricmc.fabric-loom" version "1.15-SNAPSHOT"
+    id "net.fabricmc.fabric-loom" version "1.16-SNAPSHOT"
     id "de.maxhenkel.cursegradle" version "1.5.1"
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -14,7 +14,7 @@ minecraft {
             workingDir = layout.projectDirectory.dir('run')
 
             systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
-            systemProperty 'forge.enabledGameTestNamespaces', 'examplemod'
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
 
             args "-mixin.config=${mod_id}.mixins.json", "-mixin.config=${mod_id}.forge.mixins.json"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,26 +3,26 @@ group=com.github.glitchfiend
 release_channel=beta
 
 # Common
-minecraft_version=26.1.1
+minecraft_version=26.1.2
 common_runs_enabled=false
 common_client_run_name=Common Client
 common_server_run_name=Common Server
 
 # Forge
-forge_version=63.0.0
-forge_version_range=[63.0.0,)
-forge_loader_version_range=[63,)
+forge_version=64.0.4
+forge_version_range=[62.0.0,)
+forge_loader_version_range=[62,)
 
 # NeoForge
 ## neo_form_version -> From https://projects.neoforged.net/neoforged/neoform
-neoforge_version=26.1.1.0-beta
+neoforge_version=26.1.2.12-beta
 neoforge_version_range=[26.1,)
 neoforge_loader_version_range=[1,)
-neo_form_version=26.1.1-1
+neo_form_version=26.1.2-1
 
 # Fabric
-fabric_version=0.145.2+26.1.1
-fabric_loader_version=0.18.5
+fabric_version=0.146.0+26.1.2
+fabric_loader_version=0.19.2
 
 # Mod options
 mod_id=terrablender
@@ -44,6 +44,7 @@ org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+org.gradle.jvmargs=--enable-native-access=ALL-UNNAMED
 # The configuration cache breaks Curse builds
 org.gradle.configuration-cache=false
 


### PR DESCRIPTION
## Summary

Update TerraBlender’s 26.1.2 build tooling and CI and Gradle so it will be compatible with future gradle versions and to remove any deprecation warnings.

## Changes

- Updated all mod loaders and Loom to latest versions.
- Update GitHub Actions to latest versions.
- Switch CI Java from Oracle JDK 25 to Eclipse Temurin / Adoptium 25, it should be more reliable and is recommended by Sodium developers on their Github.
- Update deprecated Gradle syntax in the root build and common module.
- Lowered Forge Version Range to 62 (26.1) as the project should be compatible with 26.1 versions still and that the minimum requirements for Fabric and NeoForge are 26.1 as well, so just made it match.
- `--enable-native-access=ALL-UNNAMED` was added to prevent this warning below to the CI pipeline and gradle.properties, a tiny nit pick.

```
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by net.rubygrapefruit.platform.internal.NativeLibraryLoader
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
```

Verified with `./gradlew.bat publishToMavenLocal --no-daemon`
